### PR TITLE
BBR-46 #close Turn off filter audit feature if empty repo host is provided

### DIFF
--- a/TabMon/LogPoller/LogPollerAgent.cs
+++ b/TabMon/LogPoller/LogPollerAgent.cs
@@ -30,7 +30,17 @@ namespace TabMon.LogPoller
             this.folderToWatch = folderToWatch;
             filter = filterString;
             logsToDbConverter = new LogsToDbConverter();
-            tableauRepo = new Tableau9RepoConn( repoHost, repoPort, repoUser, repoPass, repoDb );
+            // 
+            tableauRepo = null;
+            if (ShouldUseRepo(repoHost))
+            {
+                tableauRepo = new Tableau9RepoConn(repoHost, repoPort, repoUser, repoPass, repoDb);
+            }
+        }
+
+        private static bool ShouldUseRepo(string repoHost)
+        {
+            return !String.IsNullOrEmpty(repoHost);
         }
 
 

--- a/TabMon/LogPoller/LogsToDbConverter.cs
+++ b/TabMon/LogPoller/LogsToDbConverter.cs
@@ -242,17 +242,26 @@ namespace TabMon.LogPoller
         {
             DateTime timestamp = DateTime.Parse(ts);
 
-            //Log.Info("parsed datetime:" + timestamp);
+            // If the repo is null we just return nada.
+            if (repo == null) return MakeEmptyViewPath();
 
+            // Otherwise look up from the repo
             var viewPath = repo.getViewPathForVizQLSessionId(vizqlSessionId, timestamp);
             if (viewPath.isEmpty())
             {
                 Log.Fatal("Cannot find view path for session!");
-                viewPath.workbook = "<WORKBOOK>";
-                viewPath.view = "<VIEW>";
-                viewPath.ip = "0.0.0.0";
+                viewPath = MakeEmptyViewPath();
             }
 
+            return viewPath;
+        }
+
+        private static ViewPath MakeEmptyViewPath()
+        {
+            ViewPath viewPath;
+            viewPath.workbook = "<WORKBOOK>";
+            viewPath.view = "<VIEW>";
+            viewPath.ip = "0.0.0.0";
             return viewPath;
         }
 


### PR DESCRIPTION
If the configuration file contains an empty TableauRepo host:

``` xml
  <!-- The empty host tells to ignore the repo and dont look up view/workbooks in the repo -->
  <TableauRepo Host="" Port="8060" Username="readonly" Password="onlyread" Db="workgroup"/>
```

Then the repo isnt used for workbook/view lookups for filter changes.
