### PR TITLE
Set max size of log roll backup value to 100 by default

### DIFF
--- a/PalMon/Config/Log.config
+++ b/PalMon/Config/Log.config
@@ -15,7 +15,7 @@
     <file value="Logs\PalMon.log.txt" />
     <appendToFile value="true" />
     <rollingStyle value="Size" />
-    <maxSizeRollBackups value="10" />
+    <maxSizeRollBackups value="100" />
     <maximumFileSize value="1MB" />
     <staticLogFileName value="true" />
     <layout type="log4net.Layout.PatternLayout">


### PR DESCRIPTION
Requested by Tamas Radvany. Let's make his life easier! :)
