### PR TITLE
Quit when we face issues while checking license

### DIFF
--- a/PalMon/PalMonAgent.cs
+++ b/PalMon/PalMonAgent.cs
@@ -91,6 +91,7 @@ namespace PalMon
             catch (Exception e)
             {
                 Log.Fatal("Error during license check.", e);
+                Environment.Exit(-1);
             }
         }
 


### PR DESCRIPTION
- For example when there is no Tableau repository, exception was thrown and program continued running happily ever after catching that exception.
