### PR TITLE
fix: postgres lines ending in a backslash

### DIFF
--- a/PalMon/Output/OutputDrivers/PostgresOutput.cs
+++ b/PalMon/Output/OutputDrivers/PostgresOutput.cs
@@ -71,7 +71,7 @@ namespace PalMon.Output
                     foreach (DataRow rowToWrite in rows.Rows)
                     {
                         var row = String.Join("\t", ToTSVLine(rowToWrite.ItemArray));
-                        // if the row ends with a backslash, we need to add another one to it
+                        // if the row ends with a backslash, we need to add a space after it
                         if (row.Last() == '\\') row += " ";
                         writer.WriteLine(row);
                     }


### PR DESCRIPTION
fix: add an extra space to the end of the line if it ends in a backslash, so postgres recognizes the line ending properly
