### PR TITLE
Send agent Timezone offsest to the server for serverlog parsing

### DIFF
--- a/PaletteInsightAgent/Helpers/APIClient.cs
+++ b/PaletteInsightAgent/Helpers/APIClient.cs
@@ -91,7 +91,15 @@ namespace PaletteInsightAgent.Helpers
 
         private static string UploadUrl(string package, string maxId)
         {
-            var url = String.Format("{0}/upload?pkg={1}&host={2}", config.Endpoint, package, HostName);
+            // Get the timezone on each send, so that if the server clock timezone is
+            // changed while the agent is running, we are keeping up with the changes
+            var timezoneName = TimezoneHelpers.WindowsToIana( TimeZoneInfo.Local.Id );
+            var url = String.Format("{0}/upload?pkg={1}&host={2}&tz={3}",
+                config.Endpoint, 
+                Uri.EscapeUriString(package), 
+                Uri.EscapeUriString(HostName),
+                Uri.EscapeUriString(timezoneName));
+
             if (maxId != null)
             {
                 url = String.Format("{0}&maxid={1}", url, Uri.EscapeDataString(maxId));

--- a/PaletteInsightAgent/Helpers/TimezoneHelpers.cs
+++ b/PaletteInsightAgent/Helpers/TimezoneHelpers.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PaletteInsightAgent.Helpers
+{
+    class TimezoneHelpers
+    {
+        /// <summary>
+        /// This will return the Windows zone that matches the IANA zone, if one exists.
+        /// </summary>
+        /// <param name="ianaZoneId"></param>
+        /// <returns></returns>
+        public static string IanaToWindows(string ianaZoneId)
+        {
+            var utcZones = new[] { "Etc/UTC", "Etc/UCT", "Etc/GMT" };
+            if (utcZones.Contains(ianaZoneId, StringComparer.Ordinal))
+                return "UTC";
+
+            var tzdbSource = NodaTime.TimeZones.TzdbDateTimeZoneSource.Default;
+
+            // resolve any link, since the CLDR doesn't necessarily use canonical IDs
+            var links = tzdbSource.CanonicalIdMap
+                .Where(x => x.Value.Equals(ianaZoneId, StringComparison.Ordinal))
+                .Select(x => x.Key);
+
+            // resolve canonical zones, and include original zone as well
+            var possibleZones = tzdbSource.CanonicalIdMap.ContainsKey(ianaZoneId)
+                ? links.Concat(new[] { tzdbSource.CanonicalIdMap[ianaZoneId], ianaZoneId })
+                : links;
+
+            // map the windows zone
+            var mappings = tzdbSource.WindowsMapping.MapZones;
+            var item = mappings.FirstOrDefault(x => x.TzdbIds.Any(possibleZones.Contains));
+            if (item == null) return null;
+            return item.WindowsId;
+        }
+
+        /// <summary>
+        /// This will return the "primary" IANA zone that matches the given windows zone.
+        /// If the primary zone is a link, it then resolves it to the canonical ID.
+        /// </summary>
+        /// <param name="windowsZoneId"></param>
+        /// <returns></returns>
+        public static string WindowsToIana(string windowsZoneId)
+        {
+            if (windowsZoneId.Equals("UTC", StringComparison.Ordinal))
+                return "Etc/UTC";
+
+            var tzdbSource = NodaTime.TimeZones.TzdbDateTimeZoneSource.Default;
+            var tzi = TimeZoneInfo.FindSystemTimeZoneById(windowsZoneId);
+            if (tzi == null) return null;
+            var tzid = tzdbSource.MapTimeZoneId(tzi);
+            if (tzid == null) return null;
+            return tzdbSource.CanonicalIdMap[tzid];
+        }
+    }
+}

--- a/PaletteInsightAgent/PaletteInsightAgent.csproj
+++ b/PaletteInsightAgent/PaletteInsightAgent.csproj
@@ -72,6 +72,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NLog.4.2.3\lib\net45\NLog.dll</HintPath>
     </Reference>
+    <Reference Include="NodaTime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NodaTime.2.0.0-alpha20150728\lib\net4-Client\NodaTime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Npgsql, Version=3.0.5.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.3.0.5\lib\net45\Npgsql.dll</HintPath>
       <Private>True</Private>
@@ -118,6 +122,7 @@
     <Compile Include="Helpers\APIClient.cs" />
     <Compile Include="Helpers\TableHelper.cs" />
     <Compile Include="Configuration\ConfigurationLoader.cs" />
+    <Compile Include="Helpers\TimezoneHelpers.cs" />
     <Compile Include="LicenseChecker\LicenseChecker.cs" />
     <Compile Include="LicensePublicKey.cs" />
     <Compile Include="Output\DBWriter.cs" />

--- a/PaletteInsightAgent/packages.config
+++ b/PaletteInsightAgent/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
   <package id="NLog" version="4.2.3" targetFramework="net45" />
+  <package id="NodaTime" version="2.0.0-alpha20150728" targetFramework="net45" />
   <package id="Npgsql" version="3.0.5" targetFramework="net45" />
   <package id="PaletteAlertsCore" version="1.0.0.20" targetFramework="net45" />
   <package id="PaletteAlertsNLog" version="1.0.0.20" targetFramework="net45" />

--- a/PaletteInsightAgentServiceInstaller/Product.wxs
+++ b/PaletteInsightAgentServiceInstaller/Product.wxs
@@ -73,6 +73,7 @@
         <File Id="SodiumDLL" Name="Sodium.dll" DiskId="1" Vital="yes" Source="$(var.BinFolder)\Sodium.dll" />
         <File Id="LicensingDLL" Name="Licensing.dll" DiskId="1" Vital="yes" Source="$(var.BinFolder)\Licensing.dll" />
         <File Id="YamlDotNetDLL" Name="YamlDotNet.dll" DiskId="1" Vital="yes" Source="$(var.BinFolder)\YamlDotNet.dll" />
+        <File Id="NodaTimeDLL" Name="NodaTime.dll" DiskId="1" Vital="yes" Source="$(var.BinFolder)\NodaTime.dll" />
       </Component>
       <Component Id="Utilities" Guid="93dd2c94-e909-4b30-a2ed-80e78d53ed5b">
         <!-- Helper Utilities -->


### PR DESCRIPTION
(to make sure that we are always correct, we have to send the timezone names in the Olson(IANA) format, which the C# default tools ignore for some reason, hence the usage of the NodaTime library, which was the easiest to use (nuget) sollution.

This PR goes hand-in-hand with the timezon-offset PR of insight-server
