### PR TITLE
fix: escape single backslashes in the CSV writer

### DIFF
--- a/PaletteInsightAgent/Output/CsvSerializer.cs
+++ b/PaletteInsightAgent/Output/CsvSerializer.cs
@@ -100,7 +100,10 @@ namespace PaletteInsightAgent.Output
 
         public static string EscapeForCsv(string field)
         {
-            return field.Replace("\r", "\\015")
+            return field
+                // escpe the backslash first
+                .Replace("\\", "\\\\")
+                .Replace("\r", "\\015")
                 .Replace("\n", "\\012")
                 .Replace("\0", "")
                 .Replace("\v", "\\013");


### PR DESCRIPTION
This should fix the errors we are seeing on GE-staging and GE-prod.
