### PR TITLE
Fix workgroupyml handling

### DIFF
--- a/PaletteInsightAgent/Configuration/ConfigurationLoader.cs
+++ b/PaletteInsightAgent/Configuration/ConfigurationLoader.cs
@@ -323,9 +323,6 @@ namespace PaletteInsight
                 public string ConnectionsFile { get; set; }
 
                 public TableauConnectionInfo Connection { get; set; }
-
-                // [YamlMember(Alias = "datacollector.postgres.tablename")]
-                // public string DatabaseName { get; set; }
             }
 
             public class TableauConnectionInfo


### PR DESCRIPTION
On our multi-node staging server Agent was not able to find the repository as it was trying to find it from key in the workgroup.yml that does not exist in that setup.
